### PR TITLE
avrogen.exe: prevent clashes with namespaces that include Avro.

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -764,7 +764,7 @@ namespace Avro
             // create function call Schema.Parse(json)
             var cpe = new CodePrimitiveExpression(schema.ToString());
             var cmie = new CodeMethodInvokeExpression(
-                new CodeMethodReferenceExpression(new CodeTypeReferenceExpression(typeof(Schema)), "Parse"),
+                new CodeMethodReferenceExpression(new CodeTypeReferenceExpression("Schema"), "Parse"),
                 new CodeExpression[] { cpe });
             codeField.InitExpression = cmie;
             ctd.Members.Add(codeField);

--- a/lang/csharp/src/apache/main/CodeGen/CodeGenUtil.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGenUtil.cs
@@ -44,8 +44,8 @@ namespace Avro
                 new CodeNamespaceImport("System"),
                 new CodeNamespaceImport("System.Collections.Generic"),
                 new CodeNamespaceImport("System.Text"),
-                new CodeNamespaceImport("Avro"),
-                new CodeNamespaceImport("Avro.Specific") };
+                new CodeNamespaceImport("global::Avro"),
+                new CodeNamespaceImport("global::Avro.Specific") };
 
             FileComment = new CodeCommentStatement(
 @"------------------------------------------------------------------------------


### PR DESCRIPTION
Classes generated by avrogen.exe clash with projects that include namespaces that include the text `Avro.` (e.g. Confluent.Kafka.Avro.UnitTests). This PR resolves that.