### PR TITLE
ignore GetTypes type load failure

### DIFF
--- a/lang/csharp/src/apache/codegen/Avro.codegen.csproj
+++ b/lang/csharp/src/apache/codegen/Avro.codegen.csproj
@@ -25,7 +25,7 @@
     <PackageId>Confluent.Apache.Avro.AvroGen</PackageId>
     <Title>Confluent.Apache.Avro.AvroGen</Title>
     <AssemblyName>avrogen</AssemblyName>
-    <VersionPrefix>1.7.7.4</VersionPrefix>
+    <VersionPrefix>1.7.7.5</VersionPrefix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/lang/csharp/src/apache/ipc/Avro.ipc.csproj
+++ b/lang/csharp/src/apache/ipc/Avro.ipc.csproj
@@ -25,7 +25,7 @@
     <PackageId>Confluent.Apache.Avro.ipc</PackageId>
     <Title>Confluent.Apache.Avro.ipc</Title>
     <AssemblyName>Confluent.Apache.Avro.ipc</AssemblyName>
-    <VersionPrefix>1.7.7.4</VersionPrefix>
+    <VersionPrefix>1.7.7.5</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/lang/csharp/src/apache/main/Avro.main.csproj
+++ b/lang/csharp/src/apache/main/Avro.main.csproj
@@ -25,7 +25,7 @@
     <PackageId>Confluent.Apache.Avro</PackageId>
     <Title>Confluent.Apache.Avro</Title>
     <AssemblyName>Confluent.Apache.Avro</AssemblyName>
-    <VersionPrefix>1.7.7.4</VersionPrefix>
+    <VersionPrefix>1.7.7.5</VersionPrefix>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
+++ b/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -142,7 +142,14 @@ namespace Avro.Specific
                     if (assembly.FullName.StartsWith("MonoDevelop.NUnit"))
                         continue;
 
-                    types = assembly.GetTypes();
+                    try
+                    {
+                        types = assembly.GetTypes();
+                    }
+                    catch
+                    {
+                        continue;
+                    }
 
                     // Change the search to look for Types by both NAME and FULLNAME
                     foreach (Type t in types)

--- a/lang/csharp/src/apache/msbuild/Avro.msbuild.csproj
+++ b/lang/csharp/src/apache/msbuild/Avro.msbuild.csproj
@@ -25,7 +25,7 @@
     <PackageId>Confluent.Apache.Avro.msbuild</PackageId>
     <Title>Confluent.Apache.Avro.msbuild</Title>
     <AssemblyName>Confluent.Apache.Avro.msbuild</AssemblyName>
-    <VersionPrefix>1.7.7.4</VersionPrefix>
+    <VersionPrefix>1.7.7.5</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/lang/csharp/src/apache/perf/Avro.perf.csproj
+++ b/lang/csharp/src/apache/perf/Avro.perf.csproj
@@ -25,7 +25,7 @@
     <PackageId>Confluent.Apache.Avro.perf</PackageId>
     <Title>Confluent.Apache.Avro.perf</Title>
     <AssemblyName>Confluent.Apache.Avro.perf</AssemblyName>
-    <VersionPrefix>1.7.7.4</VersionPrefix>
+    <VersionPrefix>1.7.7.5</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/lang/csharp/src/apache/test/Avro.test.csproj
+++ b/lang/csharp/src/apache/test/Avro.test.csproj
@@ -25,7 +25,7 @@
     <PackageId>Confluent.Apache.Avro.test</PackageId>
     <Title>Confluent.Apache.Avro.test</Title>
     <AssemblyName>Confluent.Apache.Avro.test</AssemblyName>
-    <VersionPrefix>1.7.7.4</VersionPrefix>
+    <VersionPrefix>1.7.7.5</VersionPrefix>
     <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Evidently on `AppDomain.CurrentDomain.GetAssemblies()` can return assemblies that are not available in some scenarios (on .NET Core) which causes `assembly.GetTypes();` to throw an exception. Rather than abort, we should just continue the search over all the assemblies that are available.

This is being hit when Confluent.Kafka.Avro is used in the dotnet test framework. This PR will resolve that issue.