### PR TITLE
-> netcoreapp2.1 + avrogen as a tool

### DIFF
--- a/lang/csharp/src/apache/codegen/Avro.codegen.csproj
+++ b/lang/csharp/src/apache/codegen/Avro.codegen.csproj
@@ -26,8 +26,10 @@
     <Title>Confluent.Apache.Avro.AvroGen</Title>
     <AssemblyName>avrogen</AssemblyName>
     <VersionPrefix>1.7.7.5</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>avrogen</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/lang/csharp/src/apache/perf/Avro.perf.csproj
+++ b/lang/csharp/src/apache/perf/Avro.perf.csproj
@@ -26,7 +26,7 @@
     <Title>Confluent.Apache.Avro.perf</Title>
     <AssemblyName>Confluent.Apache.Avro.perf</AssemblyName>
     <VersionPrefix>1.7.7.5</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
packs avrogen as a .net core 2.1 tool. once the package is uploaded to nuget.org, users simply need to  type `dotnet tool install -g Confluent.Apache.Avro.AvroGen`, then they can use use `avrogen` on the command line.